### PR TITLE
Fix url places

### DIFF
--- a/AcaSeDona/Home.php
+++ b/AcaSeDona/Home.php
@@ -16,7 +16,7 @@ class Home {
         }
 
         Flight::view()->set("base_path", getBasePath());
-        Flight::view()->set("url_website", getWebsiteUrl(false) . '/');
+        Flight::view()->set("url_website", getBasePath());
         Flight::view()->set("recaptcha_public", getenv('RECAPTCHA_PUBLIC'));
         Flight::view()->set("ga_code", getenv('GOOGLE_ANALYTICS'));
 


### PR DESCRIPTION
En en un entorno local (ejemplo; http://localhost/acasedona) busca los puntos en
localhost/places en lugar de localhost/acasedona/places.

Para solucionar esto se puede llamar al metodo GetBasePath() en lugar de GetWebsiteUrl(). A este último hay que revisarlo